### PR TITLE
Add details tag to RELAXED config

### DIFF
--- a/lib/selma/sanitizer/config/relaxed.rb
+++ b/lib/selma/sanitizer/config/relaxed.rb
@@ -16,6 +16,7 @@ module Selma
           "colgroup",
           "data",
           "del",
+          "details",
           "div",
           "figcaption",
           "figure",


### PR DESCRIPTION
The `<summary>` tag is allowed in the `RELAXED` config, but `<details>` is missing. Adding that tag to the config.