### PR TITLE
Ensure sanitization occurs after rewrite

### DIFF
--- a/lib/selma/version.rb
+++ b/lib/selma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Selma
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/ok.rb
+++ b/ok.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "selma"
+class RemoveLinkClass
+  SELECTOR = Selma::Selector.new(match_element: %(a:not([class="anchor"])))
+
+  def selector
+    SELECTOR
+  end
+
+  def handle_element(element)
+    element.remove_attribute("class")
+  end
+end
+
+require "commonmarker"
+text = "[^1]\n[^1]:\n" * 200000
+html = Commonmarker.to_html(text, options: {
+  extension: { footnotes: true, description_lists: true },
+  render: { hardbreaks: false },
+})
+
+sanitizer_config = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
+rewriter = Selma::Rewriter.new(sanitizer: sanitizer_config, handlers: [RemoveLinkClass.new])
+rewriter.rewrite(html)

--- a/test/selma_rewriter_match_element_test.rb
+++ b/test/selma_rewriter_match_element_test.rb
@@ -23,11 +23,15 @@ class SelmaRewriterMatchElementTest < Minitest::Test
   end
 
   def test_that_it_works_with_sanitizer
-    sanitizer = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
+    config = {
+      elements: ["strong"],
+    }
+    sanitizer = Selma::Sanitizer.new(config)
     frag = "<malarky><strong><junk>Wow!</junk></strong></malarky>"
     modified_doc = Selma::Rewriter.new(sanitizer: sanitizer, handlers: [Handler.new]).rewrite(frag)
 
-    assert_equal('<strong class="boldy">Wow!</strong>', modified_doc)
+    # note that sanitization occurs *after* rewriting
+    assert_equal("<strong>Wow!</strong>", modified_doc)
   end
 
   class FirstRewrite


### PR DESCRIPTION
I believe that sanitization should happen after rewriting. To be honest, sanitization should happen _during_ the rewriting, so that the HTML doesn't need to be processed twice, but I'm fine leaving that improvement for the future. 