### PR TITLE
add testing for big strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encoding_rs"
@@ -186,7 +186,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lol_html"
@@ -321,7 +321,7 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -513,18 +513,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.97"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d30bcad206b51f2f66121190ca678dce1fdf3a2eae0ac5d838d1818b19bdf5"
+checksum = "8914b2e6af10bd50dd7aaac8c5146872d3924d6012929b4ff504e988f6badd24"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.97"
+version = "0.9.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbd92f281615f3c2dcb9dcb0f0576624752afbf9a7f99173b37c4b55b62dd8a"
+checksum = "12af68c9757d419b82d65a12b5db538990dfe9416049fea3f0ba4b9a8ca108cd"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -532,7 +532,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -681,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.68"
+version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
+checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -698,22 +698,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -736,9 +736,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -752,68 +752,68 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.68",
+ "syn 2.0.71",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -16,31 +16,31 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "bindgen"
-version = "0.69.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -51,9 +51,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "byteorder"
@@ -78,9 +78,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -117,20 +117,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -141,18 +141,24 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dtoa-short"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.33"
+name = "either"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -180,7 +186,7 @@ checksum = "a1ab991c1362ac86c61ab6f556cff143daa22e5a15e4e189df818b2fd19fe65b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -228,6 +234,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,9 +250,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lazycell"
@@ -247,25 +262,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lol_html"
@@ -273,7 +288,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4629ff9c2deeb7aad9b2d0f379fc41937a02f3b739f007732c46af40339dee5"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
  "cfg-if",
  "cssparser",
  "encoding_rs",
@@ -306,7 +321,7 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -317,9 +332,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -354,12 +369,6 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "phf"
@@ -435,18 +444,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -504,18 +513,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.85"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b780e6858b0b0eced1d55d0f097c024b77a37b41f83bd35341130f78e37c51"
+checksum = "47d30bcad206b51f2f66121190ca678dce1fdf3a2eae0ac5d838d1818b19bdf5"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.85"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44957a3bc513dad1b0f20bdd0ee3b82e729a59da44086a6b40d8bc71958a6db8"
+checksum = "3cbd92f281615f3c2dcb9dcb0f0576624752afbf9a7f99173b37c4b55b62dd8a"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -523,7 +532,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -534,9 +543,9 @@ checksum = "a35802679f07360454b418a5d1735c89716bde01d35b1560fc953c1415a0b3bb"
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -546,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rustc-hash"
@@ -604,13 +613,14 @@ dependencies = [
  "escapist",
  "lol_html",
  "magnus",
+ "rb-sys",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "seq-macro"
@@ -636,9 +646,9 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -648,9 +658,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -671,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -688,22 +698,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -725,23 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -750,62 +752,68 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.32"
+version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.68",
 ]

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source "https://rubygems.org"
 # Specified gem's dependencies in selma.gemspec
 gemspec
 
-gem "github_changelog_generator", "~> 1.16"
-
 group :debug do
   gem "amazing_print"
   gem "debug"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ The `element` argument in `handle_element` has the following methods:
 - `after(content, as: content_type)`: Inserts `content` after the text. `content_type` is either `:text` or `:html` and determines how the content will be applied.
 - `replace(content, as: content_type)`: Replaces the text node with `content`. `content_type` is either `:text` or `:html` and determines how the content will be applied.
 
+## Security
+
+Theoretically, a malicious user can provide a very large document for processing, which can exhaust the memory of the host machine. To set a limit on how much string content is processed at once, you can provide two options into the `memory` namespace:
+
+```ruby
+memory: {
+  max_allowed_memory_usage: 1000,
+  preallocated_parsing_buffer_size: 100,
+},
+```
+
+Note that `preallocated_parsing_buffer_size` must always be less than `max_allowed_memory_usage`. See [the`lol_html` project documentation](https://docs.rs/lol_html/1.2.1/lol_html/struct.MemorySettings.html) to learn more about the default values.
+
 ## Benchmarks
 
 When `bundle exec rake benchmark`, two different benchmarks are calculated. Here are those results on my machine.

--- a/README.md
+++ b/README.md
@@ -204,30 +204,33 @@ Comparing Selma against popular Ruby sanitization gems:
 <!-- prettier-ignore-start -->
 <details>
 <pre>
+input size = 25309 bytes, 0.03 MB
+
+ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 Warming up --------------------------------------
-         sanitize-sm    15.000 i/100ms
-            selma-sm   126.000 i/100ms
+         sanitize-sm    16.000 i/100ms
+            selma-sm   214.000 i/100ms
 Calculating -------------------------------------
-         sanitize-sm    155.074 (± 1.9%) i/s -      4.665k in  30.092214s
-            selma-sm      1.290k (± 1.3%) i/s -     38.808k in  30.085333s
+         sanitize-sm    171.670 (± 1.2%) i/s -      5.152k in  30.017081s
+            selma-sm      2.146k (± 3.0%) i/s -     64.414k in  30.058470s
 
 Comparison:
-            selma-sm:     1290.1 i/s
-         sanitize-sm:      155.1 i/s - 8.32x  slower
+            selma-sm:     2145.8 i/s
+         sanitize-sm:      171.7 i/s - 12.50x  slower
 
 input size = 86686 bytes, 0.09 MB
 
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 Warming up --------------------------------------
-         sanitize-md     3.000 i/100ms
-            selma-md    33.000 i/100ms
+         sanitize-md     4.000 i/100ms
+            selma-md    56.000 i/100ms
 Calculating -------------------------------------
-         sanitize-md     40.321 (± 5.0%) i/s -      1.206k in  30.004711s
-            selma-md    337.417 (± 1.5%) i/s -     10.131k in  30.032772s
+         sanitize-md     44.397 (± 2.3%) i/s -      1.332k in  30.022430s
+            selma-md    558.448 (± 1.4%) i/s -     16.800k in  30.089196s
 
 Comparison:
-            selma-md:      337.4 i/s
-         sanitize-md:       40.3 i/s - 8.37x  slower
+            selma-md:      558.4 i/s
+         sanitize-md:       44.4 i/s - 12.58x  slower
 
 input size = 7172510 bytes, 7.17 MB
 
@@ -236,12 +239,12 @@ Warming up --------------------------------------
          sanitize-lg     1.000 i/100ms
             selma-lg     1.000 i/100ms
 Calculating -------------------------------------
-         sanitize-lg      0.144 (± 0.0%) i/s -      5.000 in  34.772526s
-            selma-lg      4.026 (± 0.0%) i/s -    121.000 in  30.067415s
+         sanitize-lg      0.163 (± 0.0%) i/s -      6.000 in  37.375628s
+            selma-lg      6.750 (± 0.0%) i/s -    203.000 in  30.080976s
 
 Comparison:
-            selma-lg:        4.0 i/s
-         sanitize-lg:        0.1 i/s - 27.99x  slower
+            selma-lg:        6.7 i/s
+         sanitize-lg:        0.2 i/s - 41.32x  slower
 </pre>
 </details>
 <!-- prettier-ignore-end -->
@@ -252,41 +255,39 @@ Comparing Selma against popular Ruby HTML parsing gems:
 
 <!-- prettier-ignore-start -->
 <details>
-<pre>
-
-input size = 25309 bytes, 0.03 MB
+<pre>input size = 25309 bytes, 0.03 MB
 
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 Warming up --------------------------------------
-         nokogiri-sm    79.000 i/100ms
-       nokolexbor-sm   285.000 i/100ms
-            selma-sm   244.000 i/100ms
+         nokogiri-sm   107.000 i/100ms
+       nokolexbor-sm   340.000 i/100ms
+            selma-sm   380.000 i/100ms
 Calculating -------------------------------------
-         nokogiri-sm    807.790 (± 3.1%) i/s -     24.253k in  30.056301s
-       nokolexbor-sm      2.880k (± 6.4%) i/s -     86.070k in  30.044766s
-            selma-sm      2.508k (± 1.2%) i/s -     75.396k in  30.068792s
+         nokogiri-sm      1.073k (± 2.1%) i/s -     32.207k in  30.025474s
+       nokolexbor-sm      3.300k (±13.2%) i/s -     27.540k in  36.788212s
+            selma-sm      3.779k (± 3.4%) i/s -    113.240k in  30.013908s
 
 Comparison:
-       nokolexbor-sm:     2880.3 i/s
-            selma-sm:     2507.8 i/s - 1.15x  slower
-         nokogiri-sm:      807.8 i/s - 3.57x  slower
+            selma-sm:     3779.4 i/s
+       nokolexbor-sm:     3300.1 i/s - same-ish: difference falls within error
+         nokogiri-sm:     1073.1 i/s - 3.52x  slower
 
 input size = 86686 bytes, 0.09 MB
 
 ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
 Warming up --------------------------------------
-         nokogiri-md     8.000 i/100ms
-       nokolexbor-md    43.000 i/100ms
-            selma-md    39.000 i/100ms
+         nokogiri-md    11.000 i/100ms
+       nokolexbor-md    48.000 i/100ms
+            selma-md    53.000 i/100ms
 Calculating -------------------------------------
-         nokogiri-md     87.367 (± 3.4%) i/s -      2.624k in  30.061642s
-       nokolexbor-md    438.782 (± 3.9%) i/s -     13.158k in  30.031163s
-            selma-md    392.591 (± 3.1%) i/s -     11.778k in  30.031391s
+         nokogiri-md    103.998 (± 5.8%) i/s -      3.113k in  30.029932s
+       nokolexbor-md    428.928 (± 7.9%) i/s -     12.816k in  30.066662s
+            selma-md    492.190 (± 6.9%) i/s -     14.734k in  30.082943s
 
 Comparison:
-       nokolexbor-md:      438.8 i/s
-            selma-md:      392.6 i/s - 1.12x  slower
-         nokogiri-md:       87.4 i/s - 5.02x  slower
+            selma-md:      492.2 i/s
+       nokolexbor-md:      428.9 i/s - same-ish: difference falls within error
+         nokogiri-md:      104.0 i/s - 4.73x  slower
 
 input size = 7172510 bytes, 7.17 MB
 
@@ -296,14 +297,14 @@ Warming up --------------------------------------
        nokolexbor-lg     1.000 i/100ms
             selma-lg     1.000 i/100ms
 Calculating -------------------------------------
-         nokogiri-lg      0.895 (± 0.0%) i/s -     27.000 in  30.300832s
-       nokolexbor-lg      2.163 (± 0.0%) i/s -     65.000 in  30.085656s
-            selma-lg      5.867 (± 0.0%) i/s -    176.000 in  30.006240s
+         nokogiri-lg      0.874 (± 0.0%) i/s -     27.000 in  30.921090s
+       nokolexbor-lg      2.227 (± 0.0%) i/s -     67.000 in  30.137903s
+            selma-lg      8.354 (± 0.0%) i/s -    251.000 in  30.075227s
 
 Comparison:
-            selma-lg:        5.9 i/s
-       nokolexbor-lg:        2.2 i/s - 2.71x  slower
-         nokogiri-lg:        0.9 i/s - 6.55x  slower
+            selma-lg:        8.4 i/s
+       nokolexbor-lg:        2.2 i/s - 3.75x  slower
+         nokogiri-lg:        0.9 i/s - 9.56x  slower
 </pre>
 </details>
 <!-- prettier-ignore-end -->

--- a/ext/selma/Cargo.toml
+++ b/ext/selma/Cargo.toml
@@ -8,7 +8,10 @@ publish = false
 [dependencies]
 enum-iterator = "2.1"
 escapist = "0.0.2"
-magnus = "0.6"
+magnus = { version = "0.6", features = ["rb-sys"] }
+rb-sys = { version = "*", default-features = false, features = [
+    "stable-api-compiled-fallback",
+] }
 lol_html = "1.2"
 
 [lib]

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -119,11 +119,13 @@ impl SelmaHTMLElement {
                 .iter()
                 .for_each(|attr| match hash.aset(attr.name(), attr.value()) {
                     Ok(_) => {}
-                    Err(err) => Err(Error::new(
-                        exception::runtime_error(),
-                        format!("AttributeNameError: {err:?}"),
-                    ))
-                    .unwrap(),
+                    Err(err) => panic!(
+                        "{:?}",
+                        Error::new(
+                            exception::runtime_error(),
+                            format!("AttributeNameError: {err:?}"),
+                        )
+                    ),
                 });
         }
         Ok(hash)
@@ -139,7 +141,10 @@ impl SelmaHTMLElement {
             .for_each(|ancestor| match array.push(RString::new(ancestor)) {
                 Ok(_) => {}
                 Err(err) => {
-                    Err(Error::new(exception::runtime_error(), format!("{err:?}"))).unwrap()
+                    panic!(
+                        "{:?}",
+                        Error::new(exception::runtime_error(), format!("{err:?}"))
+                    )
                 }
             });
 

--- a/ext/selma/src/native_ref_wrap.rs
+++ b/ext/selma/src/native_ref_wrap.rs
@@ -1,15 +1,19 @@
-use std::{cell::Cell, marker::PhantomData, rc::Rc};
+use std::{
+    cell::RefCell,
+    marker::PhantomData,
+    sync::{Arc, Mutex},
+};
 
 // NOTE: My Rust isn't good enough to know what any of this does,
 // but it was taken from https://github.com/cloudflare/lol-html/blob/1a1ab2e2bf896f815fe8888ed78ccdf46d7c6b85/js-api/src/lib.rs#LL38
 
 pub struct Anchor<'r> {
-    poisoned: Rc<Cell<bool>>,
+    poisoned: Arc<Mutex<bool>>,
     lifetime: PhantomData<&'r mut ()>,
 }
 
 impl<'r> Anchor<'r> {
-    pub fn new(poisoned: Rc<Cell<bool>>) -> Self {
+    pub fn new(poisoned: Arc<Mutex<bool>>) -> Self {
         Anchor {
             poisoned,
             lifetime: PhantomData,
@@ -31,17 +35,17 @@ impl<'r> Anchor<'r> {
 // object results in exception.
 pub struct NativeRefWrap<R> {
     inner_ptr: *mut R,
-    poisoned: Rc<Cell<bool>>,
+    poisoned: Arc<Mutex<bool>>,
 }
 
 impl<R> NativeRefWrap<R> {
     pub fn wrap<I>(inner: &I) -> (Self, Anchor) {
         let wrap = NativeRefWrap {
             inner_ptr: inner as *const I as *mut R,
-            poisoned: Rc::new(Cell::new(false)),
+            poisoned: Arc::new(Mutex::new(false)),
         };
 
-        let anchor = Anchor::new(Rc::clone(&wrap.poisoned));
+        let anchor = Anchor::new(Arc::clone(&wrap.poisoned));
 
         (wrap, anchor)
     }
@@ -49,10 +53,10 @@ impl<R> NativeRefWrap<R> {
     pub fn wrap_mut<I>(inner: &mut I) -> (Self, Anchor) {
         let wrap = NativeRefWrap {
             inner_ptr: inner as *mut I as *mut R,
-            poisoned: Rc::new(Cell::new(false)),
+            poisoned: Arc::new(Mutex::new(false)),
         };
 
-        let anchor = Anchor::new(Rc::clone(&wrap.poisoned));
+        let anchor = Anchor::new(Arc::clone(&wrap.poisoned));
 
         (wrap, anchor)
     }
@@ -70,7 +74,8 @@ impl<R> NativeRefWrap<R> {
     }
 
     fn assert_not_poisoned(&self) -> Result<(), &'static str> {
-        if self.poisoned.get() {
+        let lock = self.poisoned.lock().unwrap();
+        if *lock {
             Err("The object has been freed and can't be used anymore.")
         } else {
             Ok(())

--- a/ext/selma/src/native_ref_wrap.rs
+++ b/ext/selma/src/native_ref_wrap.rs
@@ -4,8 +4,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-// NOTE: My Rust isn't good enough to know what any of this does,
-// but it was taken from https://github.com/cloudflare/lol-html/blob/1a1ab2e2bf896f815fe8888ed78ccdf46d7c6b85/js-api/src/lib.rs#LL38
+// NOTE: this was taken from https://github.com/cloudflare/lol-html/blob/1a1ab2e2bf896f815fe8888ed78ccdf46d7c6b85/js-api/src/lib.rs#LL38
 
 pub struct Anchor<'r> {
     poisoned: Arc<Mutex<bool>>,

--- a/ext/selma/src/native_ref_wrap.rs
+++ b/ext/selma/src/native_ref_wrap.rs
@@ -1,5 +1,4 @@
 use std::{
-    cell::RefCell,
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
@@ -22,7 +21,7 @@ impl<'r> Anchor<'r> {
 
 // impl Drop for Anchor<'_> {
 //     fn drop(&mut self) {
-//         self.poisoned.replace(true);
+//         *self.poisoned.lock().unwrap() = true;
 //     }
 // }
 

--- a/ext/selma/src/sanitizer.rs
+++ b/ext/selma/src/sanitizer.rs
@@ -338,7 +338,7 @@ impl SelmaSanitizer {
         element: &mut Element,
         element_sanitizer: &ElementSanitizer,
         attr_name: &String,
-        attr_val: &String,
+        attr_val: &str,
     ) -> Result<bool, AttributeNameError> {
         let mut allowed: bool = false;
         let element_allowed_attrs = element_sanitizer.allowed_attrs.contains(attr_name);
@@ -390,7 +390,7 @@ impl SelmaSanitizer {
         attr_val.contains("://")
     }
 
-    fn has_allowed_protocol(protocols_allowed: &[String], attr_val: &String) -> bool {
+    fn has_allowed_protocol(protocols_allowed: &[String], attr_val: &str) -> bool {
         if protocols_allowed.contains(&"all".to_string()) {
             return true;
         }
@@ -549,7 +549,7 @@ impl SelmaSanitizer {
     ) -> &'a mut ElementSanitizer {
         element_sanitizers
             .entry(element_name.to_string())
-            .or_insert_with(ElementSanitizer::default)
+            .or_default()
     }
 }
 

--- a/lib/selma/config.rb
+++ b/lib/selma/config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Selma
+  module Config
+    OPTIONS = {
+      memory: {
+        max_allowed_memory_usage: nil,
+        preallocated_parsing_buffer_size: nil,
+      },
+    }
+  end
+end

--- a/lib/selma/version.rb
+++ b/lib/selma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Selma
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/script/generate_changelog
+++ b/script/generate_changelog
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-bundle exec github_changelog_generator -u gjtorikian -p selma --token $GITHUB_TOKEN

--- a/test/selma_maliciousness_test.rb
+++ b/test/selma_maliciousness_test.rb
@@ -214,20 +214,4 @@ class SelmaMaliciousnessTest < Minitest::Test
       end
     end
   end
-
-  def test_massive_files_err_gracefully
-    base_text = ->(itr) {
-      %|<p data-sourcepos="#{itr}:1-#{itr}:4"><sup data-sourcepos="#{itr}:1-#{itr}:4" class="footnote-ref"><a href="#fn-#{itr}" id="fnref-#{itr}" data-footnote-ref>#{itr}</a></sup></p>|
-    }
-
-    str = []
-    100000.times do |itr|
-      str << base_text.call(itr)
-    end
-    html = str.join("\n")
-
-    sanitizer_config = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
-    rewriter = Selma::Rewriter.new(sanitizer: sanitizer_config, handlers: [RemoveLinkClass.new, RemoveIdAttributes.new, BaseRemoveRel.new])
-    rewriter.rewrite(html)
-  end
 end

--- a/test/selma_maliciousness_test.rb
+++ b/test/selma_maliciousness_test.rb
@@ -167,4 +167,67 @@ class SelmaMaliciousnessTest < Minitest::Test
       Selma::Rewriter.new(sanitizer: sanitizer).rewrite(html)
     end
   end
+
+  class RemoveLinkClass
+    SELECTOR = Selma::Selector.new(match_element: %(a:not([class="anchor"])))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      element.remove_attribute("class")
+    end
+  end
+
+  class RemoveIdAttributes
+    SELECTOR = Selma::Selector.new(match_element: %(a[id], li[id]))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      # footnote ids should not be removed
+      return if element.tag_name == "li"
+      return if element.tag_name == "a"
+
+      # links with generated header anchors should not be removed
+      return if element.tag_name == "a" && element["class"] == "anchor"
+
+      element.remove_attribute("id")
+    end
+  end
+
+  class BaseRemoveRel
+    SELECTOR = Selma::Selector.new(match_element: %(a))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      # we allow rel="license" to support the Rel-license microformat
+      # http://microformats.org/wiki/rel-license
+      unless element["rel"] == "license"
+        element.remove_attribute("rel")
+      end
+    end
+  end
+
+  def test_massive_files_err_gracefully
+    base_text = ->(itr) {
+      %|<p data-sourcepos="#{itr}:1-#{itr}:4"><sup data-sourcepos="#{itr}:1-#{itr}:4" class="footnote-ref"><a href="#fn-#{itr}" id="fnref-#{itr}" data-footnote-ref>#{itr}</a></sup></p>|
+    }
+
+    str = []
+    100000.times do |itr|
+      str << base_text.call(itr)
+    end
+    html = str.join("\n")
+
+    sanitizer_config = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
+    rewriter = Selma::Rewriter.new(sanitizer: sanitizer_config, handlers: [RemoveLinkClass.new, RemoveIdAttributes.new, BaseRemoveRel.new])
+    rewriter.rewrite(html)
+  end
 end

--- a/test/selma_rewriter_match_element_test.rb
+++ b/test/selma_rewriter_match_element_test.rb
@@ -23,11 +23,15 @@ class SelmaRewriterMatchElementTest < Minitest::Test
   end
 
   def test_that_it_works_with_sanitizer
-    sanitizer = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
+    config = {
+      elements: ["strong"],
+    }
+    sanitizer = Selma::Sanitizer.new(config)
     frag = "<malarky><strong><junk>Wow!</junk></strong></malarky>"
     modified_doc = Selma::Rewriter.new(sanitizer: sanitizer, handlers: [Handler.new]).rewrite(frag)
 
-    assert_equal('<strong class="boldy">Wow!</strong>', modified_doc)
+    # note that sanitization occurs *after* rewriting
+    assert_equal("<strong>Wow!</strong>", modified_doc)
   end
 
   class FirstRewrite

--- a/test/selma_rewriter_test.rb
+++ b/test/selma_rewriter_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SelmaRewriterTest < Minitest::Test
+  def test_max_memory_settings_must_be_correctly_set
+    fragment = "12345"
+    assert_raises(ArgumentError) do # missing preallocated_parsing_buffer_size
+      Selma::Rewriter.new(options: { memory: { max_allowed_memory_usage: 4 } }).rewrite(fragment)
+    end
+  end
+
+  class RemoveLinkClass
+    SELECTOR = Selma::Selector.new(match_element: %(a:not([class="anchor"])))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      element.remove_attribute("class")
+    end
+  end
+
+  class RemoveIdAttributes
+    SELECTOR = Selma::Selector.new(match_element: %(a[id], li[id]))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      # footnote ids should not be removed
+      return if element.tag_name == "li"
+      return if element.tag_name == "a"
+
+      # links with generated header anchors should not be removed
+      return if element.tag_name == "a" && element["class"] == "anchor"
+
+      element.remove_attribute("id")
+    end
+  end
+
+  class BaseRemoveRel
+    SELECTOR = Selma::Selector.new(match_element: %(a))
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      # we allow rel="license" to support the Rel-license microformat
+      # http://microformats.org/wiki/rel-license
+      unless element["rel"] == "license"
+        element.remove_attribute("rel")
+      end
+    end
+  end
+
+  def test_max_memory_settings_work
+    base_text = ->(itr) {
+      %|<p data-sourcepos="#{itr}:1-#{itr}:4"><sup data-sourcepos="#{itr}:1-#{itr}:4" class="footnote-ref"><a href="#fn-#{itr}" id="fnref-#{itr}" data-footnote-ref>#{itr}</a></sup></p>|
+    }
+
+    str = []
+    10.times do |itr|
+      str << base_text.call(itr)
+    end
+    html = str.join("\n")
+
+    sanitizer_config = Selma::Sanitizer.new(Selma::Sanitizer::Config::RELAXED)
+    rewriter = Selma::Rewriter.new(sanitizer: sanitizer_config, handlers: [RemoveLinkClass.new, RemoveIdAttributes.new, BaseRemoveRel.new], options: { memory: { max_allowed_memory_usage: html.length / 2, preallocated_parsing_buffer_size: html.length / 4 } })
+    assert_raises(RuntimeError) do
+      rewriter.rewrite(html)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,12 @@ def nest_html_content(html_content, depth)
   "#{"<span>" * depth}#{html_content}#{"</span>" * depth}"
 end
 
+FIXTURES_DIR = "test/fixtures"
+
+def load_fixture(file)
+  File.read(File.join(FIXTURES_DIR, file))
+end
+
 STRINGS = {
   basic: {
     html: '<b>Lo<!-- comment -->rem</b> <a href="pants" title="foo" style="text-decoration: underline;">ipsum</a> <a href="http://foo.com/"><strong>dolor</strong></a> sit<br/>amet <style>.foo { color: #fff; }</style> <script>alert("hello world");</script>',


### PR DESCRIPTION
It's possible to provide Selma with a very large piece of HTML, which can exhaust the memory on the host machine. To work around this, you can set an upper limit of how much memory the project can consume while running.