### PR TITLE
Use lol_html's on_end_tag convenience method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -19,29 +19,27 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "cexpr"
@@ -54,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clang-sys"
@@ -94,29 +92,30 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -129,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -170,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "escapist"
@@ -185,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "foldhash"
@@ -197,15 +196,15 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -214,18 +213,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lazy_static"
@@ -234,32 +233,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lol_html"
@@ -305,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -398,36 +391,36 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rb-sys"
-version = "0.9.124"
+version = "0.9.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85c4188462601e2aa1469def389c17228566f82ea72f137ed096f21591bc489"
+checksum = "d7d7c9560fe42dcffa576941394075f18a17dce89fcf718a2fa90b7dc2134d12"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.124"
+version = "0.9.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
+checksum = "f1688e8f32967ba48c89e4dfa283b57f901075f542fc7ee9c3d7c5f9091ca1d9"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -440,15 +433,15 @@ dependencies = [
 
 [[package]]
 name = "rb-sys-env"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f8d2924cf136a1315e2b4c7460a39f62ef11ee5d522df9b2750fab55b868b6"
+checksum = "cca7ad6a7e21e72151d56fe2495a259b5670e204c3adac41ee7ef676ea08117a"
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -458,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -469,21 +462,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "selectors"
@@ -499,7 +495,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -516,10 +512,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "seq-macro"
-version = "0.3.5"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -561,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "shell-words"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -573,27 +575,27 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -602,18 +604,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -622,70 +624,12 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"

--- a/ext/selma/src/html.rs
+++ b/ext/selma/src/html.rs
@@ -1,12 +1,9 @@
-use magnus::{Error, Module, RModule};
-
-#[derive(Clone, Debug)]
-#[magnus::wrap(class = "Selma::HTML")]
-pub(crate) struct SelmaHTML {}
+use magnus::{Error, Module, RModule, Ruby};
 
 pub fn init(m_selma: RModule) -> Result<(), Error> {
+    let ruby = Ruby::get().unwrap();
     let c_html = m_selma
-        .define_class("HTML", magnus::class::object())
+        .define_class("HTML", ruby.class_object())
         .expect("cannot define class Selma::HTML");
 
     element::init(c_html).expect("cannot define Selma::HTML::Element class");

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -42,7 +42,10 @@ impl SelmaHTMLElement {
         if let Ok(element) = binding.element.get_mut() {
             match element.set_tag_name(&name) {
                 Ok(_) => Ok(()),
-                Err(err) => Err(Error::new(ruby.exception_runtime_error(), format!("{err:?}"))),
+                Err(err) => Err(Error::new(
+                    ruby.exception_runtime_error(),
+                    format!("{err:?}"),
+                )),
             }
         } else {
             Err(Error::new(

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use crate::native_ref_wrap::NativeRefWrap;
 use lol_html::html_content::Element;
-use magnus::{exception, method, Error, Module, RArray, RClass, RHash, RString, Value};
+use magnus::{method, Error, Module, RArray, RClass, RHash, Ruby, Value};
 
 struct HTMLElement {
     element: NativeRefWrap<Element<'static, 'static>>,
@@ -29,7 +29,7 @@ impl SelmaHTMLElement {
         match binding.element.get() {
             Ok(e) => Ok(e.tag_name().to_string()),
             Err(_) => Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`tag_name` is not available",
             )),
         }
@@ -37,15 +37,16 @@ impl SelmaHTMLElement {
 
     fn set_tag_name(&self, name: String) -> Result<(), Error> {
         let mut binding = self.0.borrow_mut();
+        let ruby = Ruby::get().unwrap();
 
         if let Ok(element) = binding.element.get_mut() {
             match element.set_tag_name(&name) {
                 Ok(_) => Ok(()),
-                Err(err) => Err(Error::new(exception::runtime_error(), format!("{err:?}"))),
+                Err(err) => Err(Error::new(ruby.exception_runtime_error(), format!("{err:?}"))),
             }
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                ruby.exception_runtime_error(),
                 "`set_tag_name` is not available",
             ))
         }
@@ -58,7 +59,7 @@ impl SelmaHTMLElement {
             Ok(e.is_self_closing())
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`is_self_closing` is not available",
             ))
         }
@@ -71,7 +72,7 @@ impl SelmaHTMLElement {
             Ok(e.has_attribute(&attr))
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`is_self_closing` is not available",
             ))
         }
@@ -85,17 +86,18 @@ impl SelmaHTMLElement {
 
     fn set_attribute(&self, attr: String, value: String) -> Result<String, Error> {
         let mut binding = self.0.borrow_mut();
+        let ruby = Ruby::get().unwrap();
         if let Ok(element) = binding.element.get_mut() {
             match element.set_attribute(&attr, &value) {
                 Ok(_) => Ok(value),
                 Err(err) => Err(Error::new(
-                    exception::runtime_error(),
+                    ruby.exception_runtime_error(),
                     format!("AttributeNameError: {err:?}"),
                 )),
             }
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                ruby.exception_runtime_error(),
                 "`tag_name` is not available",
             ))
         }
@@ -111,7 +113,8 @@ impl SelmaHTMLElement {
 
     fn get_attributes(&self) -> Result<RHash, Error> {
         let binding = self.0.borrow();
-        let hash = RHash::new();
+        let ruby = Ruby::get().unwrap();
+        let hash = ruby.hash_new();
 
         if let Ok(e) = binding.element.get() {
             e.attributes()
@@ -121,7 +124,7 @@ impl SelmaHTMLElement {
                     Err(err) => panic!(
                         "{:?}",
                         Error::new(
-                            exception::runtime_error(),
+                            ruby.exception_runtime_error(),
                             format!("AttributeNameError: {err:?}"),
                         )
                     ),
@@ -132,17 +135,18 @@ impl SelmaHTMLElement {
 
     fn get_ancestors(&self) -> Result<RArray, Error> {
         let binding = self.0.borrow();
-        let array = RArray::new();
+        let ruby = Ruby::get().unwrap();
+        let array = ruby.ary_new();
 
         binding
             .ancestors
             .iter()
-            .for_each(|ancestor| match array.push(RString::new(ancestor)) {
+            .for_each(|ancestor| match array.push(ruby.str_new(ancestor)) {
                 Ok(_) => {}
                 Err(err) => {
                     panic!(
                         "{:?}",
-                        Error::new(exception::runtime_error(), format!("{err:?}"))
+                        Error::new(ruby.exception_runtime_error(), format!("{err:?}"))
                     )
                 }
             });
@@ -244,7 +248,7 @@ impl SelmaHTMLElement {
         match binding.element.get() {
             Ok(e) => Ok(e.removed()),
             Err(_) => Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`is_removed` is not available",
             )),
         }
@@ -252,8 +256,9 @@ impl SelmaHTMLElement {
 }
 
 pub fn init(c_html: RClass) -> Result<(), Error> {
+    let ruby = Ruby::get().unwrap();
     let c_element = c_html
-        .define_class("Element", magnus::class::object())
+        .define_class("Element", ruby.class_object())
         .expect("cannot define class Selma::HTML::Element");
 
     c_element.define_method("tag_name", method!(SelmaHTMLElement::tag_name, 0))?;

--- a/ext/selma/src/html/end_tag.rs
+++ b/ext/selma/src/html/end_tag.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use crate::native_ref_wrap::NativeRefWrap;
 use lol_html::html_content::EndTag;
-use magnus::{method, Error, Module, RClass};
+use magnus::{method, Error, Module, RClass, Ruby};
 
 struct HTMLEndTag {
     end_tag: NativeRefWrap<EndTag<'static>>,
@@ -25,8 +25,9 @@ impl SelmaHTMLEndTag {
 }
 
 pub fn init(c_html: RClass) -> Result<(), Error> {
+    let ruby = Ruby::get().unwrap();
     let c_end_tag = c_html
-        .define_class("EndTag", magnus::class::object())
+        .define_class("EndTag", ruby.class_object())
         .expect("cannot define class Selma::HTML::EndTag");
 
     c_end_tag.define_method("tag_name", method!(SelmaHTMLEndTag::tag_name, 0))?;

--- a/ext/selma/src/html/text_chunk.rs
+++ b/ext/selma/src/html/text_chunk.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 
 use crate::native_ref_wrap::NativeRefWrap;
 use lol_html::html_content::{TextChunk, TextType};
-use magnus::{exception, method, Error, Module, RClass, Symbol, Value};
+use magnus::{method, Error, Module, RClass, Ruby, Symbol, Value};
 
 struct HTMLTextChunk {
     text_chunk: NativeRefWrap<TextChunk<'static>>,
@@ -49,7 +49,7 @@ impl SelmaHTMLTextChunk {
             Ok(tc.as_str().to_string())
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`to_s` is not available",
             ))
         }
@@ -57,19 +57,20 @@ impl SelmaHTMLTextChunk {
 
     fn text_type(&self) -> Result<Symbol, Error> {
         let binding = self.0.borrow();
+        let ruby = Ruby::get().unwrap();
 
         if let Ok(tc) = binding.text_chunk.get() {
             match tc.text_type() {
-                TextType::Data => Ok(Symbol::new("data")),
-                TextType::PlainText => Ok(Symbol::new("plain_text")),
-                TextType::RawText => Ok(Symbol::new("raw_text")),
-                TextType::ScriptData => Ok(Symbol::new("script")),
-                TextType::RCData => Ok(Symbol::new("rc_data")),
-                TextType::CDataSection => Ok(Symbol::new("cdata_section")),
+                TextType::Data => Ok(ruby.to_symbol("data")),
+                TextType::PlainText => Ok(ruby.to_symbol("plain_text")),
+                TextType::RawText => Ok(ruby.to_symbol("raw_text")),
+                TextType::ScriptData => Ok(ruby.to_symbol("script")),
+                TextType::RCData => Ok(ruby.to_symbol("rc_data")),
+                TextType::CDataSection => Ok(ruby.to_symbol("cdata_section")),
             }
         } else {
             Err(Error::new(
-                exception::runtime_error(),
+                ruby.exception_runtime_error(),
                 "`text_type` is not available",
             ))
         }
@@ -81,7 +82,7 @@ impl SelmaHTMLTextChunk {
         match binding.text_chunk.get() {
             Ok(tc) => Ok(tc.removed()),
             Err(_) => Err(Error::new(
-                exception::runtime_error(),
+                Ruby::get().unwrap().exception_runtime_error(),
                 "`is_removed` is not available",
             )),
         }
@@ -140,8 +141,9 @@ impl SelmaHTMLTextChunk {
 }
 
 pub fn init(c_html: RClass) -> Result<(), Error> {
+    let ruby = Ruby::get().unwrap();
     let c_text_chunk = c_html
-        .define_class("TextChunk", magnus::class::object())
+        .define_class("TextChunk", ruby.class_object())
         .expect("cannot define class Selma::HTML::TextChunk");
 
     c_text_chunk.define_method("to_s", method!(SelmaHTMLTextChunk::to_s, 0))?;

--- a/ext/selma/src/lib.rs
+++ b/ext/selma/src/lib.rs
@@ -1,7 +1,7 @@
 extern crate core;
 
 use lol_html::html_content::ContentType;
-use magnus::{define_module, exception, scan_args, Error, Symbol, Value};
+use magnus::{scan_args, Error, Ruby, Symbol, Value};
 
 pub mod html;
 pub mod native_ref_wrap;
@@ -27,8 +27,9 @@ fn scan_text_args(args: &[Value]) -> Result<(String, ContentType), magnus::Error
     } else if as_sym_str == "html" {
         ContentType::Html
     } else {
+        let ruby = Ruby::get().unwrap();
         return Err(Error::new(
-            exception::runtime_error(),
+            ruby.exception_runtime_error(),
             format!("unknown symbol `{as_sym_str:?}`"),
         ));
     };
@@ -37,8 +38,8 @@ fn scan_text_args(args: &[Value]) -> Result<(String, ContentType), magnus::Error
 }
 
 #[magnus::init]
-fn init() -> Result<(), Error> {
-    let m_selma = define_module("Selma").expect("cannot define ::Selma module");
+fn init(ruby: &Ruby) -> Result<(), Error> {
+    let m_selma = ruby.define_module("Selma").expect("cannot define ::Selma module");
 
     sanitizer::init(m_selma).expect("cannot define Selma::Sanitizer class");
     rewriter::init(m_selma).expect("cannot define Selma::Rewriter class");

--- a/ext/selma/src/lib.rs
+++ b/ext/selma/src/lib.rs
@@ -39,7 +39,9 @@ fn scan_text_args(args: &[Value]) -> Result<(String, ContentType), magnus::Error
 
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
-    let m_selma = ruby.define_module("Selma").expect("cannot define ::Selma module");
+    let m_selma = ruby
+        .define_module("Selma")
+        .expect("cannot define ::Selma module");
 
     sanitizer::init(m_selma).expect("cannot define Selma::Sanitizer class");
     rewriter::init(m_selma).expect("cannot define Selma::Rewriter class");

--- a/ext/selma/src/native_ref_wrap.rs
+++ b/ext/selma/src/native_ref_wrap.rs
@@ -39,7 +39,7 @@ pub struct NativeRefWrap<R> {
 }
 
 impl<R> NativeRefWrap<R> {
-    pub fn wrap<I>(inner: &mut I) -> (Self, Anchor) {
+    pub fn wrap<I>(inner: &mut I) -> (Self, Anchor<'_>) {
         let wrap = NativeRefWrap {
             inner_ptr: inner as *mut I as *mut R,
             poisoned: Arc::new(Mutex::new(false)),

--- a/ext/selma/src/rewriter.rs
+++ b/ext/selma/src/rewriter.rs
@@ -5,7 +5,7 @@ use lol_html::{
     Settings,
 };
 use magnus::{
-    exception, function, gc, method,
+    function, gc, method,
     r_hash::ForEach,
     scan_args,
     typed_data::Obj,
@@ -84,12 +84,13 @@ impl SelmaRewriter {
     /// @return [Selma::Rewriter]
     fn new(args: &[Value]) -> Result<Self, magnus::Error> {
         let (rb_sanitizer, rb_handlers, rb_options) = Self::scan_parse_args(args)?;
+        let ruby = Ruby::get().unwrap();
 
         let sanitizer = match rb_sanitizer {
             None => {
                 // no `sanitizer:` kwarg provided, use default
                 let default_sanitizer = SelmaSanitizer::new(&[])?;
-                let wrapped_sanitizer = Obj::wrap(default_sanitizer);
+                let wrapped_sanitizer = ruby.obj_wrap(default_sanitizer);
                 // wrapped_sanitizer.funcall::<&str, (), Value>("setup", ())?;
                 Some(wrapped_sanitizer.deref().to_owned())
             }
@@ -106,7 +107,7 @@ impl SelmaRewriter {
                     if !rb_handler.respond_to("selector", true).unwrap() {
                         let classname = unsafe { rb_handler.classname() };
                         return Err(magnus::Error::new(
-                            exception::no_method_error(),
+                            ruby.exception_no_method_error(),
                             format!(
                                 "Could not call #selector on {classname:?}; is this an object that defines it?",
 
@@ -117,7 +118,7 @@ impl SelmaRewriter {
                     let rb_selector: Obj<SelmaSelector> = match rb_handler.funcall("selector", ()) {
                         Err(err) => {
                             return Err(magnus::Error::new(
-                                exception::type_error(),
+                                ruby.exception_type_error(),
                                 format!("Error instantiating selector: {err:?}"),
                             ));
                         }
@@ -140,7 +141,7 @@ impl SelmaRewriter {
 
         if sanitizer.is_none() && handlers.is_empty() {
             return Err(magnus::Error::new(
-                exception::arg_error(),
+                ruby.exception_arg_error(),
                 "Must provide a sanitizer or a handler",
             ));
         }
@@ -151,23 +152,22 @@ impl SelmaRewriter {
             None => {}
             Some(options) => {
                 options.foreach(|key: Symbol, value: RHash| {
+                    let ruby = Ruby::get().unwrap();
                     let key = key.to_string();
                     match key.as_str() {
                         "memory" => {
-                            let max_allowed_memory_usage = value.get(Symbol::new("max_allowed_memory_usage"));
-                            if max_allowed_memory_usage.is_some() {
-                                let max_allowed_memory_usage = max_allowed_memory_usage.unwrap();
+                            if let Some(max_allowed_memory_usage) = value.get(ruby.to_symbol("max_allowed_memory_usage")) {
                                 let max_allowed_memory_usage =
                                     Integer::from_value(max_allowed_memory_usage);
-                                if max_allowed_memory_usage.is_some() {
-                                    match max_allowed_memory_usage.unwrap().to_u64() {
+                                if let Some(max_allowed_memory_usage) = max_allowed_memory_usage {
+                                    match max_allowed_memory_usage.to_u64() {
                                         Ok(max_allowed_memory_usage) => {
                                             rewriter_options.memory_options.max_allowed_memory_usage =
                                                 max_allowed_memory_usage as usize;
                                         }
                                         Err(_e) => {
                                             return Err(magnus::Error::new(
-                                                exception::arg_error(),
+                                                ruby.exception_arg_error(),
                                                 "max_allowed_memory_usage must be a positive integer",
                                             ));
                                         }
@@ -177,20 +177,18 @@ impl SelmaRewriter {
                                 }
                             }
 
-                            let preallocated_parsing_buffer_size = value.get(Symbol::new("preallocated_parsing_buffer_size"));
-                            if preallocated_parsing_buffer_size.is_some() {
-                                let preallocated_parsing_buffer_size = preallocated_parsing_buffer_size.unwrap();
+                            if let Some(preallocated_parsing_buffer_size) = value.get(ruby.to_symbol("preallocated_parsing_buffer_size")) {
                                 let preallocated_parsing_buffer_size =
                                     Integer::from_value(preallocated_parsing_buffer_size);
-                                if preallocated_parsing_buffer_size.is_some() {
-                                    match preallocated_parsing_buffer_size.unwrap().to_u64() {
+                                if let Some(preallocated_parsing_buffer_size) = preallocated_parsing_buffer_size {
+                                    match preallocated_parsing_buffer_size.to_u64() {
                                         Ok(preallocated_parsing_buffer_size) => {
                                             rewriter_options.memory_options.preallocated_parsing_buffer_size =
                                                 preallocated_parsing_buffer_size as usize;
                                         }
                                         Err(_e) => {
                                             return Err(magnus::Error::new(
-                                                exception::arg_error(),
+                                                ruby.exception_arg_error(),
                                                 "preallocated_parsing_buffer_size must be a positive integer",
                                             ));
                                         }
@@ -202,7 +200,7 @@ impl SelmaRewriter {
                         }
                         _ => {
                             return Err(magnus::Error::new(
-                                exception::arg_error(),
+                                ruby.exception_arg_error(),
                                 format!("Unknown option: {key:?}"),
                             ));
                         }
@@ -218,7 +216,7 @@ impl SelmaRewriter {
             > rewriter_options.memory_options.max_allowed_memory_usage
         {
             return Err(magnus::Error::new(
-                exception::arg_error(),
+                ruby.exception_arg_error(),
                 "max_allowed_memory_usage must be greater than preallocated_parsing_buffer_size",
             ));
         }
@@ -305,7 +303,7 @@ impl SelmaRewriter {
                 None => match String::from_utf8(rewritten_html) {
                     Ok(output) => Ok(output),
                     Err(err) => Err(magnus::Error::new(
-                        exception::runtime_error(),
+                        Ruby::get().unwrap().exception_runtime_error(),
                         format!("{err:?}"),
                     )),
                 },
@@ -342,7 +340,7 @@ impl SelmaRewriter {
             Ok(rewritten_html) => match String::from_utf8(rewritten_html) {
                 Ok(output) => Ok(output),
                 Err(err) => Err(magnus::Error::new(
-                    exception::runtime_error(),
+                    Ruby::get().unwrap().exception_runtime_error(),
                     format!("{err:?}"),
                 )),
             },
@@ -471,7 +469,7 @@ impl SelmaRewriter {
                 Ok(_) => {}
                 Err(err) => {
                     return Err(magnus::Error::new(
-                        exception::runtime_error(),
+                        Ruby::get().unwrap().exception_runtime_error(),
                         format!("{err:?}"),
                     ));
                 }
@@ -485,7 +483,8 @@ impl SelmaRewriter {
         element: &mut Element,
         ancestors: &[String],
     ) -> Result<(), magnus::Error> {
-        let rb_handler = handler.rb_handler.into_value();
+        let ruby = Ruby::get().unwrap();
+        let rb_handler = handler.rb_handler.into_value_with(&ruby);
 
         // if `on_end_tag` function is defined, call it
         if rb_handler.respond_to(Self::SELMA_ON_END_TAG, true).unwrap() {
@@ -506,7 +505,7 @@ impl SelmaRewriter {
                     }
                 }))
                 .map_err(|err| {
-                    magnus::Error::new(exception::runtime_error(), err.to_string())
+                    magnus::Error::new(Ruby::get().unwrap().exception_runtime_error(), err.to_string())
                 })?;
         }
 
@@ -519,7 +518,7 @@ impl SelmaRewriter {
         match result {
             Ok(_) => Ok(()),
             Err(err) => Err(magnus::Error::new(
-                exception::runtime_error(),
+                ruby.exception_runtime_error(),
                 format!("{err:?}"),
             )),
         }
@@ -529,7 +528,8 @@ impl SelmaRewriter {
         handler: &Handler,
         text_chunk: &mut TextChunk,
     ) -> Result<(), magnus::Error> {
-        let rb_handler = handler.rb_handler.into_value();
+        let ruby = Ruby::get().unwrap();
+        let rb_handler = handler.rb_handler.into_value_with(&ruby);
 
         // prevents missing `handle_text_chunk` function
         let content = text_chunk.as_str();
@@ -551,7 +551,7 @@ impl SelmaRewriter {
         match result {
             Ok(_) => Ok(()),
             Err(err) => Err(magnus::Error::new(
-                exception::runtime_error(),
+                ruby.exception_runtime_error(),
                 format!("{err:?}"),
             )),
         }
@@ -575,8 +575,9 @@ impl RewriterOptions {
 }
 
 pub fn init(m_selma: RModule) -> Result<(), magnus::Error> {
+    let ruby = Ruby::get().unwrap();
     let c_rewriter = m_selma
-        .define_class("Rewriter", magnus::class::object())
+        .define_class("Rewriter", ruby.class_object())
         .expect("cannot define class Selma::Rewriter");
 
     c_rewriter.define_singleton_method("new", function!(SelmaRewriter::new, -1))?;

--- a/ext/selma/src/rewriter.rs
+++ b/ext/selma/src/rewriter.rs
@@ -505,7 +505,10 @@ impl SelmaRewriter {
                     }
                 }))
                 .map_err(|err| {
-                    magnus::Error::new(Ruby::get().unwrap().exception_runtime_error(), err.to_string())
+                    magnus::Error::new(
+                        Ruby::get().unwrap().exception_runtime_error(),
+                        err.to_string(),
+                    )
                 })?;
         }
 

--- a/ext/selma/src/rewriter.rs
+++ b/ext/selma/src/rewriter.rs
@@ -430,14 +430,12 @@ impl SelmaRewriter {
 
                 let closure_element_stack = element_stack.clone();
 
-                if let Some(end_tag_handlers) = el.end_tag_handlers() {
-                    end_tag_handlers.push(lol_html::EndTagHandler::into(Box::new(
-                        move |_end_tag| {
-                            closure_element_stack.as_ref().borrow_mut().pop();
-                            Ok(())
-                        },
-                    )));
-                }
+                let handler: lol_html::EndTagHandler<'static> = Box::new(move |_end_tag| {
+                    closure_element_stack.as_ref().borrow_mut().pop();
+                    Ok(())
+                });
+                // ignore void elements (lol_html's void list may differ from selma's `self_closing`)
+                let _ = el.on_end_tag(handler);
 
                 Ok(())
             }));
@@ -491,11 +489,8 @@ impl SelmaRewriter {
 
         // if `on_end_tag` function is defined, call it
         if rb_handler.respond_to(Self::SELMA_ON_END_TAG, true).unwrap() {
-            // TODO: error here is an "EndTagError"
             element
-                .end_tag_handlers()
-                .unwrap()
-                .push(Box::new(move |end_tag| {
+                .on_end_tag(Box::new(move |end_tag| {
                     let (ref_wrap, anchor) = NativeRefWrap::wrap(end_tag);
 
                     let rb_end_tag = SelmaHTMLEndTag::new(ref_wrap);
@@ -509,7 +504,10 @@ impl SelmaRewriter {
                         Ok(_) => Ok(()),
                         Err(err) => Err(err.to_string().into()),
                     }
-                }));
+                }))
+                .map_err(|err| {
+                    magnus::Error::new(exception::runtime_error(), err.to_string())
+                })?;
         }
 
         let (ref_wrap, anchor) = NativeRefWrap::wrap(element);

--- a/ext/selma/src/sanitizer.rs
+++ b/ext/selma/src/sanitizer.rs
@@ -685,13 +685,11 @@ impl SelmaSanitizer {
 
     fn check_if_end_tag_needs_removal(element: &mut Element) {
         if element.removed() && !crate::tags::Tag::tag_from_element(element).self_closing {
-            element
-                .end_tag_handlers()
-                .unwrap()
-                .push(Box::new(move |end| {
-                    Self::remove_end_tag(end);
-                    Ok(())
-                }));
+            // ignore void elements (lol_html's void list may differ from selma's `self_closing`)
+            let _ = element.on_end_tag(Box::new(move |end| {
+                Self::remove_end_tag(end);
+                Ok(())
+            }));
         }
     }
 

--- a/ext/selma/src/sanitizer.rs
+++ b/ext/selma/src/sanitizer.rs
@@ -5,7 +5,7 @@ use lol_html::{
     html_content::{Comment, ContentType, Doctype, Element, EndTag},
 };
 use magnus::{
-    class, eval, exception, function, method,
+    eval, function, method,
     r_hash::ForEach,
     scan_args,
     value::{Opaque, ReprValue},
@@ -125,22 +125,22 @@ impl SelmaSanitizer {
                 allowed_protocols.foreach(|element_name: String, protocols: RHash| {
                     protocols.foreach(|attribute_name: String, protocol_list: Value| {
                         let protocols: RArray;
-                        if protocol_list.is_kind_of(class::array()) {
+                        if protocol_list.is_kind_of(ruby.class_array()) {
                             protocols = RArray::from_value(protocol_list).unwrap();
                             if protocols.includes(ruby.to_symbol("all")) {
                                 return Err(magnus::Error::new(
-                                    exception::arg_error(),
+                                    ruby.exception_arg_error(),
                                     "`:all` must be passed outside of an array".to_string(),
                                 ));
                             }
-                        } else if protocol_list.is_kind_of(class::symbol())
+                        } else if protocol_list.is_kind_of(ruby.class_symbol())
                             && Symbol::from_value(protocol_list) == eval(":all").unwrap()
                         {
-                            protocols = RArray::new();
+                            protocols = ruby.ary_new();
                             protocols.push(ruby.to_symbol("all"))?;
                         } else {
                             return Err(magnus::Error::new(
-                                exception::arg_error(),
+                                ruby.exception_arg_error(),
                                 "Protocol list must be an array, or just `:all`".to_string(),
                             ));
                         }
@@ -220,15 +220,15 @@ impl SelmaSanitizer {
         //  end
         // end
         if let Some(remove_contents) = config.get(ruby.to_symbol("remove_contents")) {
-            if remove_contents.is_kind_of(class::true_class())
-                || remove_contents.is_kind_of(class::false_class())
+            if remove_contents.is_kind_of(ruby.class_true_class())
+                || remove_contents.is_kind_of(ruby.class_false_class())
             {
                 Self::set_all_flags(
                     flags,
                     Self::SELMA_SANITIZER_REMOVE_CONTENTS,
                     remove_contents.to_bool(),
                 );
-            } else if remove_contents.is_kind_of(class::array()) {
+            } else if remove_contents.is_kind_of(ruby.class_array()) {
                 let elements = RArray::from_value(remove_contents).unwrap();
                 elements
                     .into_iter()
@@ -245,7 +245,7 @@ impl SelmaSanitizer {
                     });
             } else {
                 return Err(magnus::Error::new(
-                    exception::arg_error(),
+                    ruby.exception_arg_error(),
                     "remove_contents must be `true`, `false`, or an array".to_string(),
                 ));
             }
@@ -354,11 +354,12 @@ impl SelmaSanitizer {
         attr_name: String,
         allow_list: RArray,
     ) {
+        let ruby = Ruby::get().unwrap();
         let protocol_sanitizers = &mut element_sanitizer.protocol_sanitizers.borrow_mut();
 
         for allowed_protocol in allow_list.into_iter() {
             let protocol_list = protocol_sanitizers.get_mut(&attr_name);
-            if allowed_protocol.is_kind_of(class::string()) {
+            if allowed_protocol.is_kind_of(ruby.class_string()) {
                 match protocol_list {
                     None => {
                         protocol_sanitizers
@@ -366,7 +367,7 @@ impl SelmaSanitizer {
                     }
                     Some(protocol_list) => protocol_list.push(allowed_protocol.to_string()),
                 }
-            } else if allowed_protocol.is_kind_of(class::symbol()) {
+            } else if allowed_protocol.is_kind_of(ruby.class_symbol()) {
                 let protocol_config = allowed_protocol.inspect();
                 if protocol_config == ":relative" {
                     match protocol_list {
@@ -708,8 +709,9 @@ impl SelmaSanitizer {
 }
 
 pub fn init(m_selma: RModule) -> Result<(), magnus::Error> {
+    let ruby = Ruby::get().unwrap();
     let c_sanitizer = m_selma
-        .define_class("Sanitizer", magnus::class::object())
+        .define_class("Sanitizer", ruby.class_object())
         .expect("cannot define class Selma::Sanitizer");
 
     c_sanitizer.define_singleton_method("new", function!(SelmaSanitizer::new, -1))?;

--- a/ext/selma/src/selector.rs
+++ b/ext/selma/src/selector.rs
@@ -1,4 +1,4 @@
-use magnus::{exception, function, scan_args, Error, Module, Object, RModule, Value};
+use magnus::{function, scan_args, Error, Module, Object, RModule, Ruby, Value};
 
 #[derive(Clone, Debug)]
 #[magnus::wrap(class = "Selma::Selector")]
@@ -14,31 +14,30 @@ impl SelmaSelector {
     fn new(args: &[Value]) -> Result<Self, Error> {
         let (match_element, match_text_within, rb_ignore_text_within) =
             Self::scan_parse_args(args)?;
+        let ruby = Ruby::get().unwrap();
 
         if match_element.is_none() && match_text_within.is_none() {
             return Err(Error::new(
-                exception::arg_error(),
+                ruby.exception_arg_error(),
                 "Neither `match_element` nor `match_text_within` option given",
             ));
         }
 
         // FIXME: not excited about this double parse work (`element!` does it too),
         // but at least we can bail ASAP if the CSS is invalid
-        if match_element.is_some() {
-            let css = match_element.as_ref().unwrap();
+        if let Some(css) = &match_element {
             if css.parse::<lol_html::Selector>().is_err() {
                 return Err(Error::new(
-                    exception::arg_error(),
+                    ruby.exception_arg_error(),
                     format!("Could not parse `match_element` (`{css:?}`) as valid CSS"),
                 ));
             }
         }
 
-        if match_text_within.is_some() {
-            let css = match_text_within.as_ref().unwrap();
+        if let Some(css) = &match_text_within {
             if css.parse::<lol_html::Selector>().is_err() {
                 return Err(Error::new(
-                    exception::arg_error(),
+                    ruby.exception_arg_error(),
                     format!("Could not parse `match_text_within` (`{css:?}`) as valid CSS",),
                 ));
             }
@@ -102,8 +101,9 @@ impl SelmaSelector {
 }
 
 pub fn init(m_selma: RModule) -> Result<(), Error> {
+    let ruby = Ruby::get().unwrap();
     let c_selector = m_selma
-        .define_class("Selector", magnus::class::object())
+        .define_class("Selector", ruby.class_object())
         .expect("cannot define class Selma::Selector");
 
     c_selector.define_singleton_method("new", function!(SelmaSelector::new, -1))?;

--- a/test/selma_rewriter_text_test.rb
+++ b/test/selma_rewriter_text_test.rb
@@ -278,10 +278,10 @@ class SelmaRewriterTextTest < Minitest::Test
       html_attrs = default_img_attrs(name).transform_keys(&:to_sym)
         .merge!({}).transform_keys(&:to_sym)
         .each_with_object([]) do |(attr, value), arr|
-          next if value.nil?
+        next if value.nil?
 
-          value = value.respond_to?(:call) && value.call(name) || value
-          arr << %(#{attr}="#{value}")
+        value = value.respond_to?(:call) && value.call(name) || value
+        arr << %(#{attr}="#{value}")
       end.compact.join(" ")
 
       "<img #{html_attrs}>"


### PR DESCRIPTION
## Summary
- Stacks on top of #136 (lol_html 2.8.1 bump).
- Replaces three `el.end_tag_handlers().unwrap().push(Box::new(...))` call sites in `rewriter.rs` and `sanitizer.rs` with the new `Element::on_end_tag` convenience added in lol_html 2.8.
- The user-facing dispatch in `process_element_handlers` now surfaces lol_html's `"<tag> can't have content"` error as a magnus `RuntimeError` instead of panicking via `.unwrap()`. The two internal call sites continue to swallow the void-element case to preserve prior behavior (selma's `self_closing` table and lol_html's void-element list don't fully overlap — e.g. SVG `<path>`).

## Test plan
- [x] `bundle exec rake compile`
- [x] `bundle exec rake test` — 201 runs, 975 assertions, 0 failures