### PR TITLE
Test nested :not() selector support

### DIFF
--- a/test/selma_selector_test.rb
+++ b/test/selma_selector_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "test_helper"
+
 class SelmaSelectorTest < Minitest::Test
   def test_that_it_raise_against_invalid_css
     assert_raises(ArgumentError) do
@@ -11,5 +13,33 @@ class SelmaSelectorTest < Minitest::Test
     assert_raises(ArgumentError) do
       Selma::Selector.new(match_element: "")
     end
+  end
+
+  def test_that_it_accepts_nested_not_with_simple_selector
+    # supported as of lol_html 2.8
+    Selma::Selector.new(match_element: "div:not(:not(.foo))")
+    Selma::Selector.new(match_element: ":not(:not(:not(span)))")
+  end
+
+  class NestedNotHandler
+    SELECTOR = Selma::Selector.new(match_element: "a:not(:not(.keep))")
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      element["data-matched"] = "true"
+    end
+  end
+
+  def test_nested_not_selector_matches_expected_elements
+    frag = %(<a class="keep">yes</a><a class="other">no</a>)
+    out = Selma::Rewriter.new(sanitizer: nil, handlers: [NestedNotHandler.new]).rewrite(frag)
+
+    assert_equal(
+      %(<a class="keep" data-matched="true">yes</a><a class="other">no</a>),
+      out,
+    )
   end
 end


### PR DESCRIPTION
## Summary
- Stacks on top of #136 (lol_html 2.8.1 bump).
- lol_html 2.8 added support for nested `:not()` with simple selectors. This adds parser-level coverage (`Selma::Selector.new(match_element: "div:not(:not(.foo))")` no longer raises) and a functional rewriter test confirming `a:not(:not(.keep))` matches the expected `<a>` elements.

## Test plan
- [x] `bundle exec rake test` — 203 runs, 976 assertions, 0 failures