### PR TITLE
feat(element): Expose attribute source locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The `element` argument in `handle_element` has the following methods:
 - `remove_attribute`: Remove an attribute
 - `has_attribute?`: A bool which identifies whether or not the element has an attribute
 - `attributes`: List all the attributes
+- `attribute_source_location(name)`: Returns the byte ranges of an attribute's name and value within the original input as `{ name: Range, value: Range | nil }`, or `nil` if the attribute is missing or was added/modified during the rewrite. Pure boolean attributes written without `=` (e.g. `<input disabled>`) return `nil` because lol_html does not record their position.
 - `ancestors`: List all of an element's ancestors as an array of strings
 - `before(content, as: content_type)`: Inserts `content` before the element. `content_type` is either `:text` or `:html` and determines how the content will be applied.
 - `after(content, as: content_type)`: Inserts `content` after the element. `content_type` is either `:text` or `:html` and determines how the content will be applied.

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -142,7 +142,10 @@ impl SelmaHTMLElement {
         match attribute.value_source_location() {
             Some(loc) => {
                 let r = loc.bytes();
-                hash.aset(ruby.to_symbol("value"), ruby.range_new(r.start, r.end, true)?)?;
+                hash.aset(
+                    ruby.to_symbol("value"),
+                    ruby.range_new(r.start, r.end, true)?,
+                )?;
             }
             None => {
                 hash.aset(ruby.to_symbol("value"), ruby.qnil())?;

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -114,6 +114,44 @@ impl SelmaHTMLElement {
         }
     }
 
+    fn get_attribute_source_location(&self, attr: String) -> Result<Option<RHash>, Error> {
+        let binding = self.0.borrow();
+        let ruby = Ruby::get().unwrap();
+
+        let Ok(e) = binding.element.get() else {
+            return Ok(None);
+        };
+
+        let lowered = attr.to_lowercase();
+        let attrs = e.attributes();
+        let Some(attribute) = attrs.iter().find(|a| a.name() == lowered) else {
+            return Ok(None);
+        };
+
+        let Some(name_loc) = attribute.name_source_location() else {
+            return Ok(None);
+        };
+
+        let hash = ruby.hash_new();
+        let name_range = name_loc.bytes();
+        hash.aset(
+            ruby.to_symbol("name"),
+            ruby.range_new(name_range.start, name_range.end, true)?,
+        )?;
+
+        match attribute.value_source_location() {
+            Some(loc) => {
+                let r = loc.bytes();
+                hash.aset(ruby.to_symbol("value"), ruby.range_new(r.start, r.end, true)?)?;
+            }
+            None => {
+                hash.aset(ruby.to_symbol("value"), ruby.qnil())?;
+            }
+        }
+
+        Ok(Some(hash))
+    }
+
     fn get_attributes(&self) -> Result<RHash, Error> {
         let binding = self.0.borrow();
         let ruby = Ruby::get().unwrap();
@@ -281,6 +319,10 @@ pub fn init(c_html: RClass) -> Result<(), Error> {
         method!(SelmaHTMLElement::has_attribute, 1),
     )?;
     c_element.define_method("attributes", method!(SelmaHTMLElement::get_attributes, 0))?;
+    c_element.define_method(
+        "attribute_source_location",
+        method!(SelmaHTMLElement::get_attribute_source_location, 1),
+    )?;
     c_element.define_method("ancestors", method!(SelmaHTMLElement::get_ancestors, 0))?;
 
     c_element.define_method("before", method!(SelmaHTMLElement::before, -1))?;

--- a/test/selma_rewriter_attribute_source_location_test.rb
+++ b/test/selma_rewriter_attribute_source_location_test.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SelmaRewriterAttributeSourceLocationTest < Minitest::Test
+  class CaptureLocations
+    SELECTOR = Selma::Selector.new(match_element: "a, input, div")
+
+    attr_reader :locations
+
+    def initialize(*names)
+      @names = names
+      @locations = {}
+    end
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      @names.each do |name|
+        @locations[name] = element.attribute_source_location(name)
+      end
+    end
+  end
+
+  class ModifyAndCapture
+    SELECTOR = Selma::Selector.new(match_element: "a")
+
+    attr_reader :added_location, :original_location
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      element["data-new"] = "x"
+      @added_location = element.attribute_source_location("data-new")
+      @original_location = element.attribute_source_location("href")
+    end
+  end
+
+  def test_returns_byte_offsets_for_name_and_value
+    handler = CaptureLocations.new("href")
+    html = %(<p>hi <a href="/world">link</a></p>)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    loc = handler.locations["href"]
+
+    refute_nil(loc)
+
+    assert_equal("href", html.byteslice(loc[:name]))
+    assert_equal("/world", html.byteslice(loc[:value]))
+  end
+
+  def test_returns_empty_value_range_for_explicit_empty_value
+    handler = CaptureLocations.new("disabled")
+    html = %(<input disabled="">)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    loc = handler.locations["disabled"]
+
+    refute_nil(loc)
+    assert_equal("disabled", html.byteslice(loc[:name]))
+    assert_equal("", html.byteslice(loc[:value]))
+  end
+
+  # lol_html does not record a source location for pure-boolean
+  # attributes (those written without "="), so we surface that as nil rather
+  # than fabricating one.
+  def test_returns_nil_for_pure_boolean_attribute
+    handler = CaptureLocations.new("disabled")
+    html = %(<input disabled>)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    assert_nil(handler.locations["disabled"])
+  end
+
+  def test_returns_nil_for_missing_attribute
+    handler = CaptureLocations.new("nope")
+    html = %(<a href="/x">link</a>)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    assert_nil(handler.locations["nope"])
+  end
+
+  def test_returns_nil_for_attribute_added_during_rewrite
+    handler = ModifyAndCapture.new
+    html = %(<a href="/x">link</a>)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    assert_nil(handler.added_location)
+    refute_nil(handler.original_location)
+    assert_equal("href", html.byteslice(handler.original_location[:name]))
+    assert_equal("/x", html.byteslice(handler.original_location[:value]))
+  end
+
+  def test_distinct_offsets_for_multiple_attributes
+    handler = CaptureLocations.new("class", "data-foo")
+    html = %(<div class="a b" data-foo="baz">x</div>)
+    Selma::Rewriter.new(sanitizer: nil, handlers: [handler]).rewrite(html)
+
+    class_loc = handler.locations["class"]
+    foo_loc = handler.locations["data-foo"]
+
+    refute_nil(class_loc)
+    refute_nil(foo_loc)
+
+    assert_equal("class", html.byteslice(class_loc[:name]))
+    assert_equal("a b", html.byteslice(class_loc[:value]))
+    assert_equal("data-foo", html.byteslice(foo_loc[:name]))
+    assert_equal("baz", html.byteslice(foo_loc[:value]))
+
+    refute_equal(class_loc[:name], foo_loc[:name])
+  end
+end


### PR DESCRIPTION
## Summary
- Add `element.attribute_source_location(name)` which returns
  the byte ranges of an attribute's name and value in the
  original input as `{ name: Range, value: Range | nil }`.
- Returns `nil` when the attribute is missing, was added or
  modified during the rewrite, or is a bare boolean attribute
  (e.g. `<input disabled>`) — lol_html does not record a
  position in those cases.
- Motivated by consumers that need to map rewriter callbacks
  back to exact source bytes for precise diagnostics or
  surgical edits outside the rewriter.
- Picks up the lol_html 2.9.0 bump, which exposes the
  underlying `name_source_location` / `value_source_location`
  APIs this feature depends on.

## Test plan
- [ ] `bundle exec rake compile`
- [ ] `bundle exec rake test TEST=test/selma_rewriter_attribute_source_location_test.rb`
- [ ] Full suite: `bundle exec rake test`
- [ ] Spot-check README snippet renders correctly on GitHub