### PR TITLE
feat(element): Add `add_attribute` for valueless attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The `element` argument in `handle_element` has the following methods:
 - `self_closing?`: A bool which identifies whether or not the element is self-closing
 - `[]`: Get an attribute
 - `[]=`: Set an attribute
+- `add_attribute`: Add a valueless attribute (e.g., `data-foo`); equivalent to setting the attribute to an empty string
 - `remove_attribute`: Remove an attribute
 - `has_attribute?`: A bool which identifies whether or not the element has an attribute
 - `attributes`: List all the attributes

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -294,10 +294,7 @@ pub fn init(c_html: RClass) -> Result<(), Error> {
     )?;
     c_element.define_method("[]", method!(SelmaHTMLElement::get_attribute, 1))?;
     c_element.define_method("[]=", method!(SelmaHTMLElement::set_attribute, 2))?;
-    c_element.define_method(
-        "add_attribute",
-        method!(SelmaHTMLElement::add_attribute, 1),
-    )?;
+    c_element.define_method("add_attribute", method!(SelmaHTMLElement::add_attribute, 1))?;
     c_element.define_method(
         "remove_attribute",
         method!(SelmaHTMLElement::remove_attribute, 1),

--- a/ext/selma/src/html/element.rs
+++ b/ext/selma/src/html/element.rs
@@ -106,6 +106,28 @@ impl SelmaHTMLElement {
         }
     }
 
+    fn add_attribute(&self, attr: String) -> Result<(), Error> {
+        let mut binding = self.0.borrow_mut();
+        let ruby = Ruby::get().unwrap();
+        if let Ok(element) = binding.element.get_mut() {
+            if element.has_attribute(&attr) {
+                return Ok(());
+            }
+            match element.set_attribute(&attr, "") {
+                Ok(_) => Ok(()),
+                Err(err) => Err(Error::new(
+                    ruby.exception_runtime_error(),
+                    format!("AttributeNameError: {err:?}"),
+                )),
+            }
+        } else {
+            Err(Error::new(
+                ruby.exception_runtime_error(),
+                "`add_attribute` is not available",
+            ))
+        }
+    }
+
     fn remove_attribute(&self, attr: String) {
         let mut binding = self.0.borrow_mut();
 
@@ -272,6 +294,10 @@ pub fn init(c_html: RClass) -> Result<(), Error> {
     )?;
     c_element.define_method("[]", method!(SelmaHTMLElement::get_attribute, 1))?;
     c_element.define_method("[]=", method!(SelmaHTMLElement::set_attribute, 2))?;
+    c_element.define_method(
+        "add_attribute",
+        method!(SelmaHTMLElement::add_attribute, 1),
+    )?;
     c_element.define_method(
         "remove_attribute",
         method!(SelmaHTMLElement::remove_attribute, 1),

--- a/test/selma_rewriter_match_element_test.rb
+++ b/test/selma_rewriter_match_element_test.rb
@@ -307,6 +307,32 @@ class SelmaRewriterMatchElementTest < Minitest::Test
     Selma::Rewriter.new(sanitizer: nil, handlers: [GetHasAttr.new]).rewrite(frag)
   end
 
+  class AddAttribute
+    SELECTOR = Selma::Selector.new(match_element: "p")
+
+    def selector
+      SELECTOR
+    end
+
+    def handle_element(element)
+      element.add_attribute("data-this-is-special")
+    end
+  end
+
+  def test_that_it_adds_a_valueless_attribute
+    frag = "<p>Wow!</p>"
+    modified_doc = Selma::Rewriter.new(sanitizer: nil, handlers: [AddAttribute.new]).rewrite(frag)
+
+    assert_equal(%(<p data-this-is-special="">Wow!</p>), modified_doc)
+  end
+
+  def test_that_add_attribute_does_not_overwrite_existing_value
+    frag = %(<p data-this-is-special="yes">Wow!</p>)
+    modified_doc = Selma::Rewriter.new(sanitizer: nil, handlers: [AddAttribute.new]).rewrite(frag)
+
+    assert_equal(%(<p data-this-is-special="yes">Wow!</p>), modified_doc)
+  end
+
   class RemoveElement < Minitest::Test
     SELECTOR = Selma::Selector.new(match_element: "strong")
 


### PR DESCRIPTION
## Summary
- Adds `Selma::HTML::Element#add_attribute(name)` for setting valueless attributes (e.g. `data-foo`) without having to pass `""` via `[]=`
- lol_html still requires a value under the hood, so the attribute is written as `name=""`
- If the attribute already exists, the existing value is preserved (no-op rather than overwrite)
- Documents the new method in the README element API list
- Closes #38

## Test plan
- [ ] `bundle exec rake test` passes
- [ ] New test confirms `<p>` gains `data-this-is-special=""`
- [ ] New test confirms existing attribute value is preserved