### PR TITLE
Fix GC use-after-free of handler selectors

### DIFF
--- a/ext/selma/src/rewriter.rs
+++ b/ext/selma/src/rewriter.rs
@@ -34,7 +34,11 @@ use crate::{
 #[derive(Clone)]
 pub struct Handler {
     rb_handler: Opaque<Value>,
-    rb_selector: Opaque<Obj<SelmaSelector>>,
+    // Store the selector's data by value (Rust-owned). The `#selector` method may return a
+    // freshly-built `Selma::Selector` that nothing else on the Ruby side references; keeping a
+    // `Obj`/`Opaque` handle to it would make its lifetime depend on GC (use-after-free if it is
+    // collected while the Rewriter is alive). We only ever read Rust data off it, so clone it.
+    selector: SelmaSelector,
     // total_element_handler_calls: usize,
     // total_elapsed_element_handlers: f64,
 
@@ -126,7 +130,9 @@ impl SelmaRewriter {
                     };
                     let handler = Handler {
                         rb_handler: Opaque::from(rb_handler),
-                        rb_selector: Opaque::from(rb_selector),
+                        // clone the selector's data out of the Ruby object right away so the
+                        // Handler no longer depends on that object surviving GC (see struct docs)
+                        selector: (*rb_selector).clone(),
                         // total_element_handler_calls: 0,
                         // total_elapsed_element_handlers: 0.0,
 
@@ -364,9 +370,7 @@ impl SelmaRewriter {
         handlers.iter().for_each(|handler| {
             let element_stack: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(vec![]));
 
-            let ruby = Ruby::get().unwrap();
-
-            let selector = ruby.get_inner(handler.rb_selector);
+            let selector = &handler.selector;
 
             // TODO: test final raise by simulating errors
             if selector.match_element().is_some() {

--- a/ext/selma/src/rewriter.rs
+++ b/ext/selma/src/rewriter.rs
@@ -373,50 +373,39 @@ impl SelmaRewriter {
             let selector = &handler.selector;
 
             // TODO: test final raise by simulating errors
-            if selector.match_element().is_some() {
+            if let Some(match_element) = selector.match_element() {
                 let closure_element_stack = element_stack.clone();
 
-                element_content_handlers.push(element!(
-                    selector.match_element().unwrap(),
-                    move |el| {
-                        match Self::process_element_handlers(
-                            handler,
-                            el,
-                            &closure_element_stack.borrow(),
-                        ) {
-                            Ok(_) => Ok(()),
-                            Err(err) => Err(err.to_string().into()),
-                        }
+                element_content_handlers.push(element!(match_element, move |el| {
+                    match Self::process_element_handlers(
+                        handler,
+                        el,
+                        &closure_element_stack.borrow(),
+                    ) {
+                        Ok(_) => Ok(()),
+                        Err(err) => Err(err.to_string().into()),
                     }
-                ));
+                }));
             }
 
-            if selector.match_text_within().is_some() {
+            if let Some(match_text_within) = selector.match_text_within() {
                 let closure_element_stack = element_stack.clone();
 
-                element_content_handlers.push(text!(
-                    selector.match_text_within().unwrap(),
-                    move |text| {
-                        let element_stack = closure_element_stack.as_ref().borrow();
-                        if selector.ignore_text_within().is_some() {
-                            // check if current tag is a tag we should be ignoring text within;
-                            // also checks if tag is within an ancestery of ignored tags
-                            if selector
-                                .ignore_text_within()
-                                .unwrap()
-                                .iter()
-                                .any(|t| element_stack.contains(t))
-                            {
-                                return Ok(());
-                            }
-                        }
-
-                        match Self::process_text_handlers(handler, text) {
-                            Ok(_) => Ok(()),
-                            Err(err) => Err(err.to_string().into()),
+                element_content_handlers.push(text!(match_text_within, move |text| {
+                    let element_stack = closure_element_stack.as_ref().borrow();
+                    // check if current tag is a tag we should be ignoring text within;
+                    // also checks if tag is within an ancestery of ignored tags
+                    if let Some(ignore_text_within) = selector.ignore_text_within() {
+                        if ignore_text_within.iter().any(|t| element_stack.contains(t)) {
+                            return Ok(());
                         }
                     }
-                ));
+
+                    match Self::process_text_handlers(handler, text) {
+                        Ok(_) => Ok(()),
+                        Err(err) => Err(err.to_string().into()),
+                    }
+                }));
             }
 
             // we need to check *every* element we iterate over, to create a stack of elements

--- a/ext/selma/src/selector.rs
+++ b/ext/selma/src/selector.rs
@@ -87,16 +87,16 @@ impl SelmaSelector {
         Ok((match_element, match_text_within, rb_ignore_text_within))
     }
 
-    pub fn match_element(&self) -> Option<String> {
-        self.match_element.clone()
+    pub fn match_element(&self) -> Option<&str> {
+        self.match_element.as_deref()
     }
 
-    pub fn match_text_within(&self) -> Option<String> {
-        self.match_text_within.clone()
+    pub fn match_text_within(&self) -> Option<&str> {
+        self.match_text_within.as_deref()
     }
 
-    pub fn ignore_text_within(&self) -> Option<Vec<String>> {
-        self.ignore_text_within.clone()
+    pub fn ignore_text_within(&self) -> Option<&[String]> {
+        self.ignore_text_within.as_deref()
     }
 }
 

--- a/lib/selma/version.rb
+++ b/lib/selma/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Selma
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end

--- a/test/selma_rewriter_test.rb
+++ b/test/selma_rewriter_test.rb
@@ -130,4 +130,56 @@ class SelmaRewriterTest < Minitest::Test
     rewriter.rewrite(initial_html)
     GC.stress = false
   end
+
+  # Regression tests for GC safety of handler selectors.
+  #
+  # A handler whose #selector returns a *fresh* Selma::Selector on every call (e.g. when the
+  # selector depends on runtime context and can't be a constant) has no other Ruby reference
+  # once the Rewriter takes it. The Rewriter must not depend on that Ruby object surviving GC;
+  # otherwise GC can free it and a later #rewrite reads freed memory (an EmptySelector panic or
+  # a bogus allocation -- a fatal, uncatchable crash).
+  class FreshSelectorRewriter
+    def initialize(css = "a")
+      @css = css
+    end
+
+    # deliberately NOT memoized / not a constant
+    def selector
+      Selma::Selector.new(match_element: @css)
+    end
+
+    def handle_element(element)
+      element["data-touched"] = "1"
+    end
+  end
+
+  # Frees the fresh selector after the Rewriter is built, then reuses the slot, then rewrites.
+  def test_fresh_handler_selector_survives_gc_after_construction
+    rewriter = Selma::Rewriter.new(sanitizer: nil, handlers: [FreshSelectorRewriter.new])
+
+    GC.start(full_mark: true, immediate_sweep: true)
+    1_000_000.times { Object.new } # steady-state allocation to overwrite the freed slot
+
+    # If the selector was collected, this aborts the process instead of returning.
+    result = rewriter.rewrite("<a href='https://example.com'>x</a>")
+
+    assert_includes(result, %(data-touched="1"))
+  end
+
+  # Exercises GC *during* Rewriter construction: building many fresh selectors allocates enough
+  # (under GC.stress) that an earlier, not-yet-protected selector can be collected mid-build.
+  def test_fresh_handler_selectors_survive_gc_during_construction
+    css = ["a", "p", "div", "span", "li", "ul", "ol", "h1", "h2", "h3"]
+    html = "<div><p><a href='https://example.com'>x</a></p></div>"
+
+    GC.stress = true
+    10.times do
+      # many fresh selectors widen the window in which an earlier one can be collected
+      handlers = Array.new(20) { |i| FreshSelectorRewriter.new(css[i % css.size]) }
+      # If a selector is freed mid-construction, this aborts (EmptySelector / try to mark T_NONE).
+      Selma::Rewriter.new(sanitizer: nil, handlers: handlers).rewrite(html)
+    end
+  ensure
+    GC.stress = false
+  end
 end


### PR DESCRIPTION
## Problem

A `Selma::Rewriter` handler's `#selector` may return a freshly-built `Selma::Selector` that nothing else on the Ruby side references. The Rewriter stored an `Opaque<Obj<SelmaSelector>>` handle to it, so the selector's lifetime depended on GC:

- `SelmaRewriter::mark` never marked it, so GC could free it while the Rewriter was still alive. A later `#rewrite` then read a freed/reused slot: an empty `match_element` makes the `element!` macro panic with `EmptySelector` (magnus raises an uncatchable Ruby `fatal`, aborting the process), or garbage in the slot yields a bogus `String` length and a wild allocation / SIGABRT (`memory allocation of <huge> bytes failed`).

This is easy to hit when a handler builds a fresh selector per `#selector` call (e.g. a context-dependent selector that can't be a constant). We saw it as a flaky native crash in CI, and it can crash Puma/Sidekiq workers in production (uncatchable `fatal`).

## Why not just mark `rb_selector`?

Because selectors are built inside `#new` and held only in the Rust `handlers` `Vec` until the Rewriter object exists. A GC *during construction* can free an earlier selector before it is ever markable — with marking added, that instead surfaces as `[BUG] try to mark T_NONE object`. Marking moves the crash, it doesn't fix it.

## Fix

`#rewrite` only reads Rust-owned data off the selector (`match_element`, `match_text_within`, `ignore_text_within`), so there's no need to hold the Ruby object at all. Clone the `SelmaSelector` by value into the `Handler` at construction time and drop the `Opaque<Obj<SelmaSelector>>` handle.

```rust
// Handler
-    rb_selector: Opaque<Obj<SelmaSelector>>,
+    selector: SelmaSelector,

// in #new
-    rb_selector: Opaque::from(rb_selector),
+    selector: (*rb_selector).clone(),

// in #rewrite's handler loop
-    let ruby = Ruby::get().unwrap();
-    let selector = ruby.get_inner(handler.rb_selector);
+    let selector = &handler.selector;
```

Same class of bug as #81 (fixed in #80 for `rb_handler`); the selector was just missed.

## Tests

Two regression tests in `test/selma_rewriter_test.rb`:

1. free the fresh selector after construction, churn the heap to reuse the slot, then rewrite;
2. stress GC *during* construction with many fresh selectors.

Both abort the process on `main` and pass with this change.

Verified locally on aarch64 (macOS): the `main` build crashes on both repros (`EmptySelector` / `try to mark T_NONE object`), the patched build passes the full suite (211 runs, 0 failures). `cargo fmt --check` and `rubocop` are clean.
