### PR TITLE
fix: panics on non-ASCII attribute values in the protocol check

### DIFF
--- a/ext/selma/src/sanitizer.rs
+++ b/ext/selma/src/sanitizer.rs
@@ -551,33 +551,18 @@ impl SelmaSanitizer {
             return true;
         }
 
-        // FIXME: is there a more idiomatic way to do this?
-        let mut pos: usize = 0;
-        let mut chars = attr_val.chars();
-        let len = attr_val.len();
+        // The protocol is everything before the first `:`; a `/` or `#` before
+        // that means there is no protocol and the URL is relative.
+        let Some(idx) = attr_val.find([':', '/', '#']) else {
+            return false;
+        };
 
-        for (i, c) in attr_val.chars().enumerate() {
-            if c != ':' && c != '/' && c != '#' && pos + 1 < len {
-                pos = i + 1;
-            } else {
-                break;
-            }
+        match attr_val.as_bytes()[idx] {
+            b'/' => protocols_allowed.contains(&"/".to_string()),
+            b'#' => protocols_allowed.contains(&"#".to_string()),
+            // Allow protocol name to be case-insensitive
+            _ => protocols_allowed.contains(&attr_val[..idx].to_lowercase()),
         }
-
-        let char = chars.nth(pos).unwrap();
-
-        if char == '/' {
-            return protocols_allowed.contains(&"/".to_string());
-        }
-
-        if char == '#' {
-            return protocols_allowed.contains(&"#".to_string());
-        }
-
-        // Allow protocol name to be case-insensitive
-        let protocol = attr_val[0..pos].to_lowercase();
-
-        protocols_allowed.contains(&protocol.to_lowercase())
     }
 
     fn sanitize_class_attribute(

--- a/test/selma_sanitizer_elements_test.rb
+++ b/test/selma_sanitizer_elements_test.rb
@@ -252,6 +252,34 @@ module Selma
           assert_equal("<a>Footnote 1</a>", Selma::Rewriter.new(sanitizer: sanitizer).rewrite(input))
         end
 
+        def test_should_handle_non_ascii_urls
+          sanitizer = Selma::Sanitizer.new({
+            elements: ["a"],
+            attributes: { "a" => ["href"] },
+            protocols: { "a" => { "href" => ["http", :relative] } },
+          })
+          rewriter = Selma::Rewriter.new(sanitizer: sanitizer)
+
+          assert_equal("<a>Link</a>", rewriter.rewrite('<a href="café">Link</a>'))
+          assert_equal("<a>Link</a>", rewriter.rewrite('<a href="&nbsp;">Link</a>'))
+          assert_equal("<a>Link</a>", rewriter.rewrite('<a href="café:foo">Link</a>'))
+          assert_equal('<a href="caf%C3%A9/page">Link</a>', rewriter.rewrite('<a href="café/page">Link</a>'))
+          assert_equal('<a href="http://caf%C3%A9.example">Link</a>', rewriter.rewrite('<a href="http://café.example">Link</a>'))
+        end
+
+        def test_should_not_match_protocols_by_prefix
+          sanitizer = Selma::Sanitizer.new({
+            elements: ["a"],
+            attributes: { "a" => ["href"] },
+            protocols: { "a" => { "href" => ["http", :relative] } },
+          })
+          rewriter = Selma::Rewriter.new(sanitizer: sanitizer)
+
+          # a value with no `:`, `/` or `#` used to be compared minus its last character
+          assert_equal("<a>Link</a>", rewriter.rewrite('<a href="httpx">Link</a>'))
+          assert_equal("<a>Link</a>", rewriter.rewrite('<a href="http">Link</a>'))
+        end
+
         def test_should_allow_all_protocols_if_asked
           input = <<~HTML
             <a href="/foo/bar">Link</a>


### PR DESCRIPTION

`has_allowed_protocol` mixes byte offsets with char indices, so any attribute value that contains a multibyte character and is checked against a protocol allowlist crashes the process:

```ruby
sanitizer = Selma::Sanitizer.new(
  elements: ["a"],
  attributes: { "a" => ["href"] },
  protocols: { "a" => { "href" => ["http", :relative] } }
)
rewriter = Selma::Rewriter.new(sanitizer: sanitizer)

rewriter.rewrite('<a href="café">x</a>')
# => called `Option::unwrap()` on a `None` value (fatal)

rewriter.rewrite('<a href="café:foo">x</a>')
# => byte index 4 is not a char boundary; it is inside 'é' (bytes 3..5) of `café:foo` (fatal)
```

The first is `chars().nth(pos).unwrap()` with `pos` bounded by the byte length, the second is `attr_val[0..pos]` sliced with a char index. Both are Rust panics, so they can't be rescued from Ruby.

This replaces the loop with `str::find` on the first `:`, `/` or `#`, which returns a byte offset on a char boundary. Behaviour for ASCII values is unchanged. The new test covers the two crashes plus the relative and absolute non-ASCII cases that already worked.