### PR TITLE
ci: Run release prep on every push to main

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "lib/selma/version.rb"
   pull_request_target:
     types:
       - closed


### PR DESCRIPTION
## Summary

Removes the `paths` filter on `lib/selma/version.rb` from the push trigger in `tag_and_release.yml`, mirroring gjtorikian/commonmarker@e63aa0d.

The paths filter predates the release-please refactor of the shared `ruby_gem_release` workflow. Under the new flow, the prepare job computes the next version itself, so gating the push trigger on `version.rb` changes meant feature merges could never open a release PR (`version.rb` only changes when a release PR merges — a chicken-and-egg deadlock). The compute step's `pending_release` guard prevents spurious PRs when the release commit itself lands.

Note: the companion commonmarker change (gjtorikian/commonmarker@0253ccd, bumping rb-sys to 0.9.130 in Cargo.lock) is already in place here via #151.

https://claude.ai/code/session_01SALeVtTq3nzFGyQixjKwqo